### PR TITLE
FAV-8 fixed an issue where array of array were not properly serialized

### DIFF
--- a/src/main/java/bio/ferlab/fhir/converter/ConverterUtils.java
+++ b/src/main/java/bio/ferlab/fhir/converter/ConverterUtils.java
@@ -16,10 +16,14 @@ public class ConverterUtils {
             throw new BadRequestException("Please verify the path argument");
         }
 
-        return navigatePath(path, path.size());
+        return navigatePath(path, true, path.size());
     }
 
     public static String navigatePath(Deque<String> path, int depth) {
+        return navigatePath(path, true, depth);
+    }
+
+    public static String navigatePath(Deque<String> path, boolean forward, int depth) {
         if (path == null) {
             throw new BadRequestException("Please verify the path argument");
         }
@@ -29,7 +33,7 @@ public class ConverterUtils {
         }
 
         StringBuilder absolutePath = new StringBuilder();
-        Iterator<String> itr = path.iterator();
+        Iterator<String> itr = (forward) ? path.iterator() : path.descendingIterator();
 
         // Root
         if (itr.hasNext()) {

--- a/src/main/java/bio/ferlab/fhir/converter/ResourceContext.java
+++ b/src/main/java/bio/ferlab/fhir/converter/ResourceContext.java
@@ -1,0 +1,112 @@
+package bio.ferlab.fhir.converter;
+
+import bio.ferlab.fhir.schema.utils.Constant;
+import ca.uhn.fhir.util.FhirTerser;
+import ca.uhn.fhir.util.TerserUtilHelper;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.r4.model.BaseResource;
+
+import java.util.*;
+
+import static bio.ferlab.fhir.converter.ConverterUtils.navigatePath;
+
+public class ResourceContext {
+
+    private final TerserUtilHelper helper;
+    private final Deque<String> path;
+    private final ArrayContext arrayState;
+
+    public ResourceContext(TerserUtilHelper terserUtilHelper) {
+        helper = terserUtilHelper;
+        path = new ArrayDeque<>();
+        arrayState = new ArrayContext();
+    }
+
+    public void addLastToPath(String value) {
+        // Format value[x] in camelCase
+        if (value.contains(Constant.VALUE) && value.length() >= 6) {
+            value = value.substring(0, 5) + String.valueOf(value.charAt(5)).toUpperCase() + value.substring(6);
+        }
+
+        path.addLast(value);
+    }
+
+    public void detectPathConflict(String absolutePath) {
+        List<IBase> parents = getTerser().getValues(getResource(), navigatePath(getPath(), getPath().size() - 1));
+        if (!parents.isEmpty()) {
+            getArrayContext().addNode(absolutePath, parents);
+        }
+    }
+
+    public TerserUtilHelper getHelper() {
+        return helper;
+    }
+
+    public FhirTerser getTerser() {
+        return helper.getTerser();
+    }
+
+    public BaseResource getResource() {
+        return helper.getResource();
+    }
+
+    public ArrayContext getArrayContext() {
+        return arrayState;
+    }
+
+    public Deque<String> getPath() {
+        return path;
+    }
+
+    public static class ArrayContext {
+        private final Map<String, Node> nodes;
+
+        public ArrayContext() {
+            nodes = new HashMap<>();
+        }
+
+        public boolean hasNode(String path) {
+            return nodes.containsKey(path);
+        }
+
+        public void addNode(String path, List<IBase> bases) {
+            if (!hasNode(path)) {
+                nodes.put(path, new Node(bases));
+            } else {
+                nodes.get(path).updateBases(bases);
+            }
+        }
+
+        public void progressNode(String path) {
+            if (hasNode(path)) {
+                this.nodes.get(path).progress();
+            }
+        }
+
+        public IBase getCurrentBase(String path) {
+            return this.nodes.get(path).getCurrentBase();
+        }
+
+        private static class Node {
+            private List<IBase> bases;
+            private int index;
+
+            protected Node(List<IBase> bases) {
+                index = 0;
+                this.bases = bases;
+            }
+
+            protected void progress() {
+                index++;
+            }
+
+            protected IBase getCurrentBase() {
+                return bases.get(index);
+            }
+
+            protected void updateBases(List<IBase> bases) {
+                this.bases = bases;
+            }
+        }
+    }
+}

--- a/src/main/test/ConverterUtilsTest.java
+++ b/src/main/test/ConverterUtilsTest.java
@@ -49,6 +49,16 @@ public class ConverterUtilsTest {
     }
 
     @Test
+    public void test_navigatePath_reverse() {
+        assertEquals("start.period.identifier", navigatePath(getDeque(), false, getDeque().size()));
+    }
+
+    @Test
+    public void test_navigatePath_reverse_get_parent() {
+        assertEquals("start.period", navigatePath(getDeque(), false, 2));
+    }
+
+    @Test
     public void test_formatSchemaName() {
         assertEquals("patient.avsc", formatSchemaName("Patient"));
     }

--- a/src/main/test/FhavroConverterTest.java
+++ b/src/main/test/FhavroConverterTest.java
@@ -57,6 +57,11 @@ public class FhavroConverterTest {
         assertBaseResource("EvidenceVariable", EvidenceVariableFixture.createEvidenceVariable(), EvidenceVariable.class);
     }
 
+    @Test
+    public void test_serialize_carePlan() {
+        assertBaseResource("CarePlan", CarePlanFixture.createCarePlan(), CarePlan.class);
+    }
+
     private <T extends BaseResource> void assertBaseResource(String name, BaseResource baseResource, Class<T> type) {
         Schema schema = FhavroConverter.loadSchema(name);
 

--- a/src/main/test/fixture/AnnotationFixture.java
+++ b/src/main/test/fixture/AnnotationFixture.java
@@ -1,0 +1,16 @@
+package fixture;
+
+import org.hl7.fhir.r4.model.Annotation;
+
+import java.util.Date;
+
+public class AnnotationFixture {
+
+    public static Annotation createAnnotation() {
+        Annotation annotation = new Annotation();
+        // annotation.setAuthor(); what the hell is a Type ?
+        annotation.setTime(new Date());
+        annotation.setText("Text!");
+        return annotation;
+    }
+}

--- a/src/main/test/fixture/CarePlanFixture.java
+++ b/src/main/test/fixture/CarePlanFixture.java
@@ -1,0 +1,46 @@
+package fixture;
+
+import org.hl7.fhir.r4.model.CarePlan;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.StringType;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class CarePlanFixture {
+
+    public static CarePlan createCarePlan() {
+        CarePlan carePlan = new CarePlan();
+        List<CodeableConcept> categories = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            categories.add(CodeableConceptFixture.createCodeableConcept(4));
+        }
+        carePlan.setCategory(categories);
+        carePlan.setStatus(CarePlan.CarePlanStatus.ONHOLD);
+        carePlan.setTitle("The Best Care Plan Ever");
+        carePlan.setPeriod(PeriodFixture.createOngoingPeriod());
+        carePlan.setCreated(new Date());
+        carePlan.setAuthor(ReferenceFixture.createAbsoluteReference());
+
+        List<CarePlan.CarePlanActivityComponent> carePlanActivityComponents = new ArrayList<>();
+        CarePlan.CarePlanActivityComponent carePlanActivityComponent = new CarePlan.CarePlanActivityComponent();
+        carePlanActivityComponent.setOutcomeCodeableConcept(List.of(CodeableConceptFixture.createCodeableConcept()));
+        carePlanActivityComponent.setProgress(List.of(AnnotationFixture.createAnnotation()));
+        carePlanActivityComponent.setReference(ReferenceFixture.createAbsoluteReference());
+
+        CarePlan.CarePlanActivityDetailComponent carePlanActivityDetailComponent = new CarePlan.CarePlanActivityDetailComponent();
+        carePlanActivityDetailComponent.setKind(CarePlan.CarePlanActivityKind.DEVICEREQUEST);
+        carePlanActivityDetailComponent.setStatusReason(CodeableConceptFixture.createCodeableConcept());
+        carePlanActivityDetailComponent.setLocationTarget(LocationFixture.createLocation());
+
+        // To see if both are going to be serialized. OR that one overwrite the other even thought they are different type.
+        carePlanActivityDetailComponent.setScheduled(PeriodFixture.createOngoingPeriod());
+        carePlanActivityDetailComponent.setScheduled(new StringType("This is a string!"));
+
+        carePlanActivityComponent.setDetail(carePlanActivityDetailComponent);
+
+        carePlan.setActivity(carePlanActivityComponents);
+        return carePlan;
+    }
+}

--- a/src/main/test/fixture/CodeableConceptFixture.java
+++ b/src/main/test/fixture/CodeableConceptFixture.java
@@ -16,8 +16,12 @@ public class CodeableConceptFixture {
     }
 
     public static CodeableConcept createCodeableConcept() {
+        return createCodeableConcept(4);
+    }
+
+    public static CodeableConcept createCodeableConcept(int size) {
         List<Coding> codings = new ArrayList<>();
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < size; i++) {
             codings.add(createCoding(String.valueOf(i)));
         }
         return new CodeableConcept()

--- a/src/main/test/fixture/LocationFixture.java
+++ b/src/main/test/fixture/LocationFixture.java
@@ -1,0 +1,16 @@
+package fixture;
+
+import org.hl7.fhir.r4.model.Location;
+
+import java.util.Arrays;
+
+public class LocationFixture {
+
+    public static Location createLocation() {
+        Location location = new Location();
+        location.setAddress(AddressFixture.createAddress());
+        location.setAvailabilityExceptions("AvailabilityException?");
+        location.setEndpoint(Arrays.asList(ReferenceFixture.createAbsoluteReference()));
+        return location;
+    }
+}


### PR DESCRIPTION
- Wrap TerserUtilHelper, the Deque that kept track of where we are in the serialization into a single class named ResourceContext
- Added ArrayContext to keep track of array of array where each absolute path that clashes with one another are tracked to return the relative parent of each children array for the FhirTerser
- Added a few public getter (e.g: getResource(), getTerser(), etc) to improve the readability of the code.