### PR TITLE
FAV-10 support private fields

### DIFF
--- a/src/main/java/bio/ferlab/fhir/converter/ConverterUtils.java
+++ b/src/main/java/bio/ferlab/fhir/converter/ConverterUtils.java
@@ -1,6 +1,7 @@
 package bio.ferlab.fhir.converter;
 
 import bio.ferlab.fhir.converter.exception.BadRequestException;
+import bio.ferlab.fhir.converter.exception.LogicException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.hl7.fhir.r4.model.Base;
@@ -84,8 +85,7 @@ public class ConverterUtils {
     }
 
     public static Base getBase(List<Base> bases) {
-        return Optional.ofNullable(bases.get(0))
-                .orElseThrow(() -> new RuntimeException("Please verify this, this isn't suppose to occur."));
+        return Optional.ofNullable(bases.get(0)).orElseThrow(LogicException::new);
     }
 
     // Standardize the date formatting within a String

--- a/src/main/java/bio/ferlab/fhir/converter/ElementConverter.java
+++ b/src/main/java/bio/ferlab/fhir/converter/ElementConverter.java
@@ -1,0 +1,152 @@
+package bio.ferlab.fhir.converter;
+
+import bio.ferlab.fhir.converter.exception.LogicException;
+import bio.ferlab.fhir.converter.exception.UnionTypeException;
+import bio.ferlab.fhir.schema.utils.Constant;
+import ca.uhn.fhir.context.FhirContext;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.hl7.fhir.r4.model.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ElementConverter {
+
+    private static final FhirContext fhirContext;
+
+    ElementConverter() {
+    }
+
+    static {
+        fhirContext = FhirContext.forR4();
+    }
+
+    public static Extension readExtension(GenericRecord genericRecord) {
+        return (Extension) readRecord(genericRecord.getSchema(), genericRecord);
+    }
+
+    private static Object read(Schema.Field field, Schema schema, Object value) {
+        switch (schema.getType()) {
+            case RECORD:
+                return readRecord(schema, (GenericRecord) value);
+            case ARRAY:
+                return readArray(field, schema, (GenericData.Array) value);
+            case MAP:
+            case UNION:
+                return readUnion(field, schema, value);
+            case ENUM:
+            case FIXED:
+            case STRING:
+                return readType(field, value);
+            case BYTES:
+                return new StringType(StandardCharsets.UTF_8.decode((ByteBuffer) value).toString());
+            case INT:
+            case LONG:
+            case DOUBLE:
+            case FLOAT:
+                return new IntegerType(value.toString());
+            case BOOLEAN:
+                return new BooleanType(value.toString());
+            case NULL:
+                return null;
+        }
+        return null;
+    }
+
+    private static Type readRecord(Schema schema, GenericRecord genericRecord) {
+        Base base = newBaseInstance(schema.getName());
+
+        boolean isNotEmpty = false;
+        for (Schema.Field field : schema.getFields()) {
+            if (field.name().startsWith("_")) {
+                continue;
+            }
+
+            if (genericRecord.hasField(field.name()) && genericRecord.get(field.name()) != null) {
+                Object object = read(field, field.schema(), genericRecord.get(field.name()));
+                if (object != null) {
+                    isNotEmpty |= parseProperty(field, base, object);
+                }
+            }
+        }
+        return (isNotEmpty) ? (Type) base : null;
+    }
+
+    private static List<Object> readArray(Schema.Field field, Schema schema, List<Object> array) {
+        if (array.isEmpty()) {
+            // This is intentional to return null and not an empty collection.
+            return null;
+        }
+
+        return array.stream()
+                .map(object -> read(field, schema.getElementType(), object))
+                .collect(Collectors.toList());
+    }
+
+    private static Type readUnion(Schema.Field field, Schema schema, Object value) {
+        for (Schema type : schema.getTypes()) {
+            try {
+                Object unionValue = read(field, type, value);
+                if (unionValue != null) {
+                    return (Type) unionValue;
+                }
+            } catch (UnionTypeException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static Type readType(Schema.Field field, Object value) {
+        if (field.name().startsWith(Constant.VALUE) && !field.name().equals(Constant.VALUE)) {
+            String elementType = field.name().replace(Constant.VALUE, "");
+            return ((StringType) newBaseInstance(elementType)).setValue(value.toString());
+        } else {
+            return new StringType(value.toString());
+        }
+    }
+
+    private static boolean parseProperty(Schema.Field field, Base base, Object object) {
+        if (object instanceof Type) {
+            return setProperty(field, base, (Type) object);
+        } else if (object instanceof List) {
+            return setProperties(field, base, ((List<Base>) object));
+        }
+        return false;
+    }
+
+    private static boolean setProperty(Schema.Field field, Base base, Type type) {
+        if (type.isPrimitive()) {
+            return setFieldProperty(field, base, type);
+        } else {
+            return type.children().stream()
+                    .filter(Property::hasValues)
+                    .anyMatch(x -> setFieldProperty(field, base, type));
+        }
+    }
+
+    private static boolean setProperties(Schema.Field field, Base base, List<Base> bases) {
+        bases.forEach(innerBase -> base.setProperty(field.name(), innerBase));
+        return true;
+    }
+
+    private static boolean setFieldProperty(Schema.Field field, Base base, Type type) {
+        if (field.name().startsWith(Constant.VALUE) && !field.name().equals(Constant.VALUE)) {
+            base.setProperty(Constant.VALUE + "[x]", type);
+        } else {
+            base.setProperty(field.name(), type);
+        }
+        return true;
+    }
+
+    private static Base newBaseInstance(String elementType) {
+        return (Base) Optional.ofNullable(fhirContext.getElementDefinition(elementType))
+                .orElseThrow(LogicException::new)
+                .newInstance();
+    }
+}

--- a/src/main/java/bio/ferlab/fhir/converter/ResourceContext.java
+++ b/src/main/java/bio/ferlab/fhir/converter/ResourceContext.java
@@ -16,11 +16,13 @@ public class ResourceContext {
     private final TerserUtilHelper helper;
     private final Deque<String> path;
     private final ArrayContext arrayState;
+    private final List<String> elements;
 
     public ResourceContext(TerserUtilHelper terserUtilHelper) {
         helper = terserUtilHelper;
         path = new ArrayDeque<>();
         arrayState = new ArrayContext();
+        elements = new ArrayList<>();
     }
 
     public void addLastToPath(String value) {
@@ -69,6 +71,15 @@ public class ResourceContext {
         }
 
         return possibleNodes.isEmpty() ? new Operation<>() : new Operation<>(possibleNodes);
+    }
+
+    // An Element may be a field[x] as well, therefore we need to record if one of the [x] has been handled to avoid conflict.
+    public void registerElements(String value) {
+        elements.add(value);
+    }
+
+    public boolean isElement(String value) {
+        return elements.stream().anyMatch(value::contains);
     }
 
     public TerserUtilHelper getHelper() {

--- a/src/main/java/bio/ferlab/fhir/converter/exception/LogicException.java
+++ b/src/main/java/bio/ferlab/fhir/converter/exception/LogicException.java
@@ -1,0 +1,9 @@
+package bio.ferlab.fhir.converter.exception;
+
+// Exception that represents error in the program logic.
+public class LogicException extends RuntimeException {
+
+    public LogicException() {
+        super("Please verify this logic, this behaviour should never occur.");
+    }
+}

--- a/src/main/java/bio/ferlab/fhir/schema/definition/ComplexDefinition.java
+++ b/src/main/java/bio/ferlab/fhir/schema/definition/ComplexDefinition.java
@@ -48,6 +48,7 @@ public class ComplexDefinition extends BaseDefinition {
         for (Iterator<Map.Entry<String, JsonNode>> it = getDefinition().get(Constant.PROPERTIES).fields(); it.hasNext(); ) {
             Map.Entry<String, JsonNode> node = it.next();
 
+            // "_" field are not supported by default, they need to be manually added using Profile.
             if (node.getKey().contains("_") || UNSUPPORTED_PROPERTIES.contains(node.getKey())) {
                 continue;
             }

--- a/src/main/java/bio/ferlab/fhir/schema/definition/specificity/ExtensionDefinition.java
+++ b/src/main/java/bio/ferlab/fhir/schema/definition/specificity/ExtensionDefinition.java
@@ -57,9 +57,6 @@ public class ExtensionDefinition extends SpecificDefinition {
                 // extensions.put("valueAttachment", new Extension("Attachment", DefinitionType.COMPLEX));
                 // extensions.put("valueRelatedArtifact", new Extension("RelatedArtifact", DefinitionType.COMPLEX));
                 extensions.put("valueContactPoint", new Extension("ContactPoint", DefinitionType.COMPLEX));
-                extensions.put("valueCount", new Extension("Count", DefinitionType.COMPLEX));
-                extensions.put("valueDistance", new Extension("Distance", DefinitionType.COMPLEX));
-                extensions.put("valueDuration", new Extension("Duration", DefinitionType.COMPLEX));
                 extensions.put("valueHumanName", new Extension("HumanName", DefinitionType.COMPLEX));
                 extensions.put("valueMoney", new Extension("Money", DefinitionType.COMPLEX));
                 extensions.put("valuePeriod", new Extension("Period", DefinitionType.COMPLEX));
@@ -67,7 +64,6 @@ public class ExtensionDefinition extends SpecificDefinition {
                 extensions.put("valueUsageContext", new Extension("UsageContext", DefinitionType.COMPLEX));
                 extensions.put("valueDosage", new Extension("Dosage", DefinitionType.COMPLEX));
                 extensions.put("valueMeta", new Extension("Meta", DefinitionType.COMPLEX));
-                extensions.put("valueQuantity", new Extension("Quantity", DefinitionType.COMPLEX));
                 extensions.put("valueRange", new Extension("Range", DefinitionType.COMPLEX));
                 extensions.put("valueRatio", new Extension("Ratio", DefinitionType.COMPLEX));
                 extensions.put("valueSampledData", new Extension("SampledData", DefinitionType.COMPLEX));
@@ -100,6 +96,10 @@ public class ExtensionDefinition extends SpecificDefinition {
                 extensions.put("valueUri", new Extension("uri", DefinitionType.PRIMITIVE));
                 extensions.put("valueUrl", new Extension("url", DefinitionType.PRIMITIVE));
                 extensions.put("valueUuid", new Extension("uuid", DefinitionType.PRIMITIVE));
+                extensions.put("valueCount", new Extension("Count", DefinitionType.COMPLEX));
+                extensions.put("valueDistance", new Extension("Distance", DefinitionType.COMPLEX));
+                extensions.put("valueDuration", new Extension("Duration", DefinitionType.COMPLEX));
+                extensions.put("valueQuantity", new Extension("Quantity", DefinitionType.COMPLEX));
                 break;
             case SIMPLE:
                 break;

--- a/src/main/java/bio/ferlab/fhir/schema/profile/Profiler.java
+++ b/src/main/java/bio/ferlab/fhir/schema/profile/Profiler.java
@@ -7,7 +7,6 @@ import bio.ferlab.fhir.schema.definition.Property;
 import bio.ferlab.fhir.schema.definition.SchemaDefinition;
 import bio.ferlab.fhir.schema.definition.specificity.ExtensionDefinition;
 import bio.ferlab.fhir.schema.repository.DefinitionRepository;
-import bio.ferlab.fhir.schema.repository.SchemaMode;
 import bio.ferlab.fhir.schema.utils.Constant;
 import bio.ferlab.fhir.schema.utils.SchemaUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/test/FhavroConverterAdvancedTest.java
+++ b/src/main/test/FhavroConverterAdvancedTest.java
@@ -1,8 +1,5 @@
 import bio.ferlab.fhir.schema.repository.SchemaMode;
-import org.hl7.fhir.r4.model.Condition;
-import org.hl7.fhir.r4.model.DocumentReference;
-import org.hl7.fhir.r4.model.Observation;
-import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.*;
 import org.junit.Test;
 
 import java.util.List;
@@ -45,19 +42,33 @@ public class FhavroConverterAdvancedTest extends BaseFhavroConverter {
         assertBaseResource("ncpi-disease", SchemaMode.ADVANCED, condition, Condition.class);
     }
 
-    // Partially working, contains private field which are not serializable. (e.g: _recordedDate which is a <dateTime> recorded as a { dateTime },
-    // profile does not describe this behaviour. If you do not consider those private fields, the test should pass.
-//    @Test
-//    public void test_serialize_ncpi_condition_disease_example_1() {
-//        Condition condition = loadExampleFromFile("ncpi-Disease-example-1.json", Condition.class);
-//        assertBaseResource("ncpi-disease", SchemaMode.ADVANCED, condition, Condition.class);
-//    }
-//
+    @Test
+    public void test_serialize_kfdrc_condition_example_1() {
+        Condition condition = loadExampleFromFile("kfdrc-Condition-example-1.json", Condition.class);
+        assertBaseResource("kfdrc-condition", SchemaMode.ADVANCED, condition, Condition.class);
+    }
 
-    // Not working due to Private fields
-//    @Test
-//    public void test_serialize_ncpi_phenotype() {
-//        Condition condition = loadExampleFromFile("ncpi-Phenotype-example-1.json", Condition.class);
-//        assertBaseResource("ncpi-phenotype", SchemaMode.ADVANCED, condition, Condition.class);
-//    }
+    @Test
+    public void test_serialize_kfdrc_observation_example_1() {
+        Observation observation = loadExampleFromFile("kfdrc-Observation-example-1.json", Observation.class);
+        assertBaseResource("kfdrc-observation", SchemaMode.ADVANCED, observation, Observation.class);
+    }
+
+    @Test
+    public void test_serialize_ncpi_Specimen_example_1() {
+        Specimen specimen = loadExampleFromFile("ncpi-Specimen-example-1.json", Specimen.class);
+        assertBaseResource("ncpi-specimen", SchemaMode.ADVANCED, specimen, Specimen.class);
+    }
+
+    @Test
+    public void test_serialize_ncpi_condition_disease_example_1() {
+        Condition condition = loadExampleFromFile("ncpi-Disease-example-1.json", Condition.class);
+        assertBaseResource("ncpi-disease", SchemaMode.ADVANCED, condition, Condition.class);
+    }
+
+    @Test
+    public void test_serialize_ncpi_phenotype() {
+        Condition condition = loadExampleFromFile("ncpi-Phenotype-example-1.json", Condition.class);
+        assertBaseResource("ncpi-phenotype", SchemaMode.ADVANCED, condition, Condition.class);
+    }
 }

--- a/src/main/test/FhavroConverterDefaultTest.java
+++ b/src/main/test/FhavroConverterDefaultTest.java
@@ -140,13 +140,6 @@ public class FhavroConverterDefaultTest extends BaseFhavroConverter {
         assertBaseResource("CarePlan", SchemaMode.DEFAULT, CarePlanFixture.createCarePlan(), CarePlan.class);
     }
 
-//    // Not working, contains private fields (e.g: _receivedTime) with data.
-//    @Test
-//    public void test_serialize_ncpi_Specimen_example_1() {
-//        Specimen specimen = loadExampleFromFile("ncpi-Specimen-example-1.json", Specimen.class);
-//        assertBaseResource("Specimen", SchemaMode.DEFAULT, specimen, Specimen.class);
-//    }
-
     // TODO FIX THIS.
     // Does not work; deceasedDateTime is converted into deceasedBoolean ?
 //    @Test

--- a/src/resources/examples/kfdrc-Condition-example-1.json
+++ b/src/resources/examples/kfdrc-Condition-example-1.json
@@ -1,0 +1,96 @@
+{
+  "resourceType": "Condition",
+  "id": "5147",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2021-10-14T16:02:29.398+00:00",
+    "source": "#g88ZTkSkNITmYf6b",
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/Condition"
+    ]
+  },
+  "identifier": [
+    {
+      "value": "01533-1-Leukemia"
+    }
+  ],
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+        "code": "inactive",
+        "display": "Inactive"
+      }
+    ],
+    "text": "No"
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+        "code": "refuted",
+        "display": "Refuted"
+      }
+    ],
+    "text": "No"
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ],
+      "text": "Health Status"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://purl.obolibrary.org/obo/mondo.owl",
+        "code": "MONDO:0005059",
+        "display": "leukemia (disease)"
+      }
+    ],
+    "text": "Leukemia"
+  },
+  "subject": {
+    "reference": "Patient/4847"
+  },
+  "_onsetDateTime": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/relative-date",
+        "extension": [
+          {
+            "url": "event",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "709491003",
+                  "display": "Enrollment in a clinical trial"
+                }
+              ]
+            }
+          },
+          {
+            "url": "relationship",
+            "valueCode": "after"
+          },
+          {
+            "url": "offset",
+            "valueDuration": {
+              "value": -97,
+              "unit": "days",
+              "system": "https://ucum.org/trac",
+              "code": "d"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/resources/examples/kfdrc-Observation-example-1.json
+++ b/src/resources/examples/kfdrc-Observation-example-1.json
@@ -1,0 +1,113 @@
+{
+  "resourceType": "Observation",
+  "id": "7798",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2021-10-14T16:09:10.553+00:00",
+    "source": "#IK4Y30BUnHavcUw6",
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
+    ]
+  },
+  "identifier": [
+    {
+      "value": "01632-Anakinra-1-height-centimeter"
+    }
+  ],
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs",
+          "display": "Vital Signs"
+        }
+      ],
+      "text": "ESI"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "8302-2",
+        "display": "Body height"
+      }
+    ],
+    "text": "height"
+  },
+  "subject": {
+    "reference": "Patient/4824"
+  },
+  "effectivePeriod": {
+    "_start": {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/relative-date",
+          "extension": [
+            {
+              "url": "event",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "709491003",
+                    "display": "Enrollment in a clinical trial"
+                  }
+                ]
+              }
+            },
+            {
+              "url": "relationship",
+              "valueCode": "after"
+            },
+            {
+              "url": "offset",
+              "valueDuration": {
+                "value": 2,
+                "unit": "days",
+                "system": "https://ucum.org/trac",
+                "code": "d"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "_end": {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/relative-date",
+          "extension": [
+            {
+              "url": "event",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "709491003",
+                    "display": "Enrollment in a clinical trial"
+                  }
+                ]
+              }
+            },
+            {
+              "url": "relationship",
+              "valueCode": "after"
+            },
+            {
+              "url": "offset",
+              "valueDuration": {
+                "value": 2,
+                "unit": "days",
+                "system": "https://ucum.org/trac",
+                "code": "d"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/resources/profiles/StructureDefinition-ncpi-phenotype.json
+++ b/src/resources/profiles/StructureDefinition-ncpi-phenotype.json
@@ -1998,6 +1998,15 @@
           "strength": "required",
           "valueSet": "https://ncpi-fhir.github.io/ncpi-fhir-ig/ValueSet/phenotype-codes"
         }
+      },
+      {
+        "id": "Condition._recordedDate",
+        "path": "Condition._recordedDate",
+        "type": [
+          {
+            "code": "Element"
+          }
+        ]
       }
     ]
   }

--- a/src/resources/schemas/advanced/kfdrc-condition.avsc
+++ b/src/resources/schemas/advanced/kfdrc-condition.avsc
@@ -397,53 +397,6 @@
                         "string"
                       ],
                       "default": null
-                    },
-                    {
-                      "type": {
-                        "type": "record",
-                        "name": "Reference",
-                        "doc": "A Reference",
-                        "namespace": "bio.ferlab.fhir",
-                        "fields": [
-                          {
-                            "name": "reference",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          },
-                          {
-                            "name": "type",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          },
-                          {
-                            "name": "identifier",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          },
-                          {
-                            "name": "display",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          }
-                        ],
-                        "logicalType": "reference",
-                        "idFieldName": "identifier",
-                        "default": {}
-                      },
-                      "name": "valueReference",
-                      "default": {}
                     }
                   ],
                   "default": {}
@@ -501,11 +454,6 @@
             {
               "type": "bio.ferlab.fhir.Coding",
               "name": "valueCoding",
-              "default": {}
-            },
-            {
-              "type": "bio.ferlab.fhir.Reference",
-              "name": "valueReference",
               "default": {}
             },
             {
@@ -911,7 +859,47 @@
             },
             {
               "name": "assigner",
-              "type": "bio.ferlab.fhir.Reference",
+              "type": {
+                "type": "record",
+                "name": "Reference",
+                "doc": "A Reference",
+                "namespace": "bio.ferlab.fhir",
+                "fields": [
+                  {
+                    "name": "reference",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "type",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "identifier",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "display",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  }
+                ],
+                "default": {}
+              },
               "default": {}
             }
           ],
@@ -979,6 +967,36 @@
         }
       ],
       "default": null
+    },
+    {
+      "name": "_onsetDateTime",
+      "type": {
+        "type": "record",
+        "name": "Element",
+        "doc": "Base definition for all elements in a resource.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          }
+        ],
+        "default": {}
+      },
+      "default": {}
     },
     {
       "name": "onsetAge",
@@ -1222,36 +1240,6 @@
         }
       ],
       "default": null
-    },
-    {
-      "name": "_recordedDate",
-      "type": {
-        "type": "record",
-        "name": "Element",
-        "doc": "Base definition for all elements in a resource.",
-        "namespace": "bio.ferlab.fhir",
-        "fields": [
-          {
-            "name": "id",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "extension",
-            "type": {
-              "type": "array",
-              "items": "bio.ferlab.fhir.Extension",
-              "default": []
-            },
-            "default": []
-          }
-        ],
-        "default": {}
-      },
-      "default": {}
     },
     {
       "type": "bio.ferlab.fhir.Reference",

--- a/src/resources/schemas/advanced/kfdrc-observation.avsc
+++ b/src/resources/schemas/advanced/kfdrc-observation.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
-  "name": "Condition",
-  "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+  "name": "Observation",
+  "doc": "Measurements and simple assertions made about a patient, device or other subject.",
   "namespace": "bio.ferlab.fhir",
   "fields": [
     {
@@ -397,53 +397,6 @@
                         "string"
                       ],
                       "default": null
-                    },
-                    {
-                      "type": {
-                        "type": "record",
-                        "name": "Reference",
-                        "doc": "A Reference",
-                        "namespace": "bio.ferlab.fhir",
-                        "fields": [
-                          {
-                            "name": "reference",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          },
-                          {
-                            "name": "type",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          },
-                          {
-                            "name": "identifier",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          },
-                          {
-                            "name": "display",
-                            "type": [
-                              "null",
-                              "string"
-                            ],
-                            "default": null
-                          }
-                        ],
-                        "logicalType": "reference",
-                        "idFieldName": "identifier",
-                        "default": {}
-                      },
-                      "name": "valueReference",
-                      "default": {}
                     }
                   ],
                   "default": {}
@@ -501,11 +454,6 @@
             {
               "type": "bio.ferlab.fhir.Coding",
               "name": "valueCoding",
-              "default": {}
-            },
-            {
-              "type": "bio.ferlab.fhir.Reference",
-              "name": "valueReference",
               "default": {}
             },
             {
@@ -894,6 +842,36 @@
                     "default": null
                   },
                   {
+                    "type": {
+                      "type": "record",
+                      "name": "Element",
+                      "doc": "Base definition for all elements in a resource.",
+                      "namespace": "bio.ferlab.fhir",
+                      "fields": [
+                        {
+                          "name": "id",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "default": null
+                        },
+                        {
+                          "name": "extension",
+                          "type": {
+                            "type": "array",
+                            "items": "bio.ferlab.fhir.Extension",
+                            "default": []
+                          },
+                          "default": []
+                        }
+                      ],
+                      "default": {}
+                    },
+                    "name": "_start",
+                    "default": {}
+                  },
+                  {
                     "name": "end",
                     "type": [
                       "null",
@@ -903,6 +881,11 @@
                       }
                     ],
                     "default": null
+                  },
+                  {
+                    "type": "bio.ferlab.fhir.Element",
+                    "name": "_end",
+                    "default": {}
                   }
                 ],
                 "default": {}
@@ -911,7 +894,47 @@
             },
             {
               "name": "assigner",
-              "type": "bio.ferlab.fhir.Reference",
+              "type": {
+                "type": "record",
+                "name": "Reference",
+                "doc": "A Reference",
+                "namespace": "bio.ferlab.fhir",
+                "fields": [
+                  {
+                    "name": "reference",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "type",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "identifier",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "display",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  }
+                ],
+                "default": {}
+              },
               "default": {}
             }
           ],
@@ -922,14 +945,30 @@
       "default": []
     },
     {
-      "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "clinicalStatus",
-      "default": {}
+      "name": "basedOn",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
     },
     {
-      "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "verificationStatus",
-      "default": {}
+      "name": "partOf",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "status",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "name": "category",
@@ -942,22 +981,8 @@
     },
     {
       "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "severity",
-      "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.CodeableConcept",
       "name": "code",
       "default": {}
-    },
-    {
-      "name": "bodySite",
-      "type": {
-        "type": "array",
-        "items": "bio.ferlab.fhir.CodeableConcept",
-        "default": []
-      },
-      "default": []
     },
     {
       "type": "bio.ferlab.fhir.Reference",
@@ -965,12 +990,21 @@
       "default": {}
     },
     {
+      "name": "focus",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
+    },
+    {
       "type": "bio.ferlab.fhir.Reference",
       "name": "encounter",
       "default": {}
     },
     {
-      "name": "onsetDateTime",
+      "name": "effectiveDateTime",
       "type": [
         "null",
         {
@@ -981,91 +1015,16 @@
       "default": null
     },
     {
-      "name": "onsetAge",
-      "type": {
-        "type": "record",
-        "name": "Age",
-        "doc": "A duration of time during which an organism (or a process) has existed.",
-        "namespace": "bio.ferlab.fhir",
-        "fields": [
-          {
-            "name": "extension",
-            "type": {
-              "type": "array",
-              "items": "bio.ferlab.fhir.Extension",
-              "default": []
-            },
-            "default": []
-          },
-          {
-            "name": "id",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "value",
-            "type": [
-              "null",
-              {
-                "type": "bytes",
-                "logicalType": "decimal",
-                "precision": 18,
-                "scale": 0
-              }
-            ],
-            "default": null
-          },
-          {
-            "name": "comparator",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "unit",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "system",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "code",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          }
-        ],
-        "default": {}
-      },
-      "default": {}
-    },
-    {
       "type": "bio.ferlab.fhir.Period",
-      "name": "onsetPeriod",
+      "name": "effectivePeriod",
       "default": {}
     },
     {
-      "name": "onsetRange",
+      "name": "effectiveTiming",
       "type": {
         "type": "record",
-        "name": "Range",
-        "doc": "A set of ordered Quantities defined by a low and high limit.",
+        "name": "Timing",
+        "doc": "Specifies an event that may occur multiple times. Timing schedules are used to record when things are planned, expected or requested to occur. The most common usage is in dosage instructions for medications. They are also used when planning care of various kinds, and may be used for reporting the schedule to which past regular activities were carried out.",
         "namespace": "bio.ferlab.fhir",
         "fields": [
           {
@@ -1086,11 +1045,23 @@
             "default": null
           },
           {
-            "name": "low",
+            "name": "event",
+            "type": {
+              "type": "array",
+              "items": {
+                "type": "long",
+                "logicalType": "timestamp-micros"
+              },
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "repeat",
             "type": {
               "type": "record",
-              "name": "Quantity",
-              "doc": "A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.",
+              "name": "Timing_Repeat",
+              "doc": "Specifies an event that may occur multiple times. Timing schedules are used to record when things are planned, expected or requested to occur. The most common usage is in dosage instructions for medications. They are also used when planning care of various kinds, and may be used for reporting the schedule to which past regular activities were carried out.",
               "namespace": "bio.ferlab.fhir",
               "fields": [
                 {
@@ -1111,7 +1082,143 @@
                   "default": null
                 },
                 {
-                  "name": "value",
+                  "type": "bio.ferlab.fhir.Duration",
+                  "name": "boundsDuration",
+                  "default": {}
+                },
+                {
+                  "name": "boundsRange",
+                  "type": {
+                    "type": "record",
+                    "name": "Range",
+                    "doc": "A set of ordered Quantities defined by a low and high limit.",
+                    "namespace": "bio.ferlab.fhir",
+                    "fields": [
+                      {
+                        "name": "extension",
+                        "type": {
+                          "type": "array",
+                          "items": "bio.ferlab.fhir.Extension",
+                          "default": []
+                        },
+                        "default": []
+                      },
+                      {
+                        "name": "id",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null
+                      },
+                      {
+                        "type": {
+                          "type": "record",
+                          "name": "Quantity",
+                          "doc": "A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.",
+                          "namespace": "bio.ferlab.fhir",
+                          "fields": [
+                            {
+                              "name": "extension",
+                              "type": {
+                                "type": "array",
+                                "items": "bio.ferlab.fhir.Extension",
+                                "default": []
+                              },
+                              "default": []
+                            },
+                            {
+                              "name": "id",
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "default": null
+                            },
+                            {
+                              "name": "value",
+                              "type": [
+                                "null",
+                                {
+                                  "type": "bytes",
+                                  "logicalType": "decimal",
+                                  "precision": 18,
+                                  "scale": 0
+                                }
+                              ],
+                              "default": null
+                            },
+                            {
+                              "name": "comparator",
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "default": null
+                            },
+                            {
+                              "name": "unit",
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "default": null
+                            },
+                            {
+                              "name": "system",
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "default": null
+                            },
+                            {
+                              "name": "code",
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "default": null
+                            }
+                          ],
+                          "default": {}
+                        },
+                        "name": "low",
+                        "default": {}
+                      },
+                      {
+                        "type": "bio.ferlab.fhir.Quantity",
+                        "name": "high",
+                        "default": {}
+                      }
+                    ],
+                    "default": {}
+                  },
+                  "default": {}
+                },
+                {
+                  "type": "bio.ferlab.fhir.Period",
+                  "name": "boundsPeriod",
+                  "default": {}
+                },
+                {
+                  "name": "count",
+                  "type": [
+                    "null",
+                    "int"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "countMax",
+                  "type": [
+                    "null",
+                    "int"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "duration",
                   "type": [
                     "null",
                     {
@@ -1124,7 +1231,20 @@
                   "default": null
                 },
                 {
-                  "name": "comparator",
+                  "name": "durationMax",
+                  "type": [
+                    "null",
+                    {
+                      "type": "bytes",
+                      "logicalType": "decimal",
+                      "precision": 18,
+                      "scale": 0
+                    }
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "durationUnit",
                   "type": [
                     "null",
                     "string"
@@ -1132,7 +1252,49 @@
                   "default": null
                 },
                 {
-                  "name": "unit",
+                  "name": "frequency",
+                  "type": [
+                    "null",
+                    "int"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "frequencyMax",
+                  "type": [
+                    "null",
+                    "int"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "period",
+                  "type": [
+                    "null",
+                    {
+                      "type": "bytes",
+                      "logicalType": "decimal",
+                      "precision": 18,
+                      "scale": 0
+                    }
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "periodMax",
+                  "type": [
+                    "null",
+                    {
+                      "type": "bytes",
+                      "logicalType": "decimal",
+                      "precision": 18,
+                      "scale": 0
+                    }
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "periodUnit",
                   "type": [
                     "null",
                     "string"
@@ -1140,18 +1302,46 @@
                   "default": null
                 },
                 {
-                  "name": "system",
-                  "type": [
-                    "null",
-                    "string"
-                  ],
-                  "default": null
+                  "name": "dayOfWeek",
+                  "type": {
+                    "type": "array",
+                    "items": {
+                      "name": "dayOfWeek",
+                      "type": "string"
+                    },
+                    "default": []
+                  },
+                  "default": []
                 },
                 {
-                  "name": "code",
+                  "name": "timeOfDay",
+                  "type": {
+                    "type": "array",
+                    "items": {
+                      "name": "timeOfDay",
+                      "type": "string"
+                    },
+                    "default": []
+                  },
+                  "default": []
+                },
+                {
+                  "name": "when",
+                  "type": {
+                    "type": "array",
+                    "items": {
+                      "name": "when",
+                      "type": "string"
+                    },
+                    "default": []
+                  },
+                  "default": []
+                },
+                {
+                  "name": "offset",
                   "type": [
                     "null",
-                    "string"
+                    "int"
                   ],
                   "default": null
                 }
@@ -1161,8 +1351,8 @@
             "default": {}
           },
           {
-            "type": "bio.ferlab.fhir.Quantity",
-            "name": "high",
+            "type": "bio.ferlab.fhir.CodeableConcept",
+            "name": "code",
             "default": {}
           }
         ],
@@ -1171,15 +1361,7 @@
       "default": {}
     },
     {
-      "name": "onsetString",
-      "type": [
-        "null",
-        "string"
-      ],
-      "default": null
-    },
-    {
-      "name": "abatementDateTime",
+      "name": "effectiveInstant",
       "type": [
         "null",
         {
@@ -1190,47 +1372,81 @@
       "default": null
     },
     {
-      "type": "bio.ferlab.fhir.Age",
-      "name": "abatementAge",
+      "name": "issued",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "performer",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "type": "bio.ferlab.fhir.Quantity",
+      "name": "valueQuantity",
       "default": {}
     },
     {
-      "type": "bio.ferlab.fhir.Period",
-      "name": "abatementPeriod",
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "valueCodeableConcept",
       "default": {}
+    },
+    {
+      "name": "valueString",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "valueBoolean",
+      "type": [
+        "null",
+        "boolean"
+      ],
+      "default": null
+    },
+    {
+      "name": "valueInteger",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
     },
     {
       "type": "bio.ferlab.fhir.Range",
-      "name": "abatementRange",
+      "name": "valueRange",
       "default": {}
     },
     {
-      "name": "abatementString",
-      "type": [
-        "null",
-        "string"
-      ],
-      "default": null
-    },
-    {
-      "name": "recordedDate",
-      "type": [
-        "null",
-        {
-          "type": "long",
-          "logicalType": "timestamp-micros"
-        }
-      ],
-      "default": null
-    },
-    {
-      "name": "_recordedDate",
+      "name": "valueRatio",
       "type": {
         "type": "record",
-        "name": "Element",
-        "doc": "Base definition for all elements in a resource.",
+        "name": "Ratio",
+        "doc": "A relationship of two Quantity values - expressed as a numerator and a denominator.",
         "namespace": "bio.ferlab.fhir",
         "fields": [
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          },
           {
             "name": "id",
             "type": [
@@ -1240,13 +1456,14 @@
             "default": null
           },
           {
-            "name": "extension",
-            "type": {
-              "type": "array",
-              "items": "bio.ferlab.fhir.Extension",
-              "default": []
-            },
-            "default": []
+            "type": "bio.ferlab.fhir.Quantity",
+            "name": "numerator",
+            "default": {}
+          },
+          {
+            "type": "bio.ferlab.fhir.Quantity",
+            "name": "denominator",
+            "default": {}
           }
         ],
         "default": {}
@@ -1254,116 +1471,142 @@
       "default": {}
     },
     {
-      "type": "bio.ferlab.fhir.Reference",
-      "name": "recorder",
-      "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.Reference",
-      "name": "asserter",
-      "default": {}
-    },
-    {
-      "name": "stage",
+      "name": "valueSampledData",
       "type": {
-        "type": "array",
-        "items": {
-          "type": "record",
-          "name": "Condition_Stage",
-          "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
-          "namespace": "bio.ferlab.fhir",
-          "fields": [
-            {
-              "name": "extension",
-              "type": {
-                "type": "array",
-                "items": "bio.ferlab.fhir.Extension",
-                "default": []
-              },
+        "type": "record",
+        "name": "SampledData",
+        "doc": "A series of measurements taken by a device, with upper and lower limits. There may be more than one dimension in the data.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
               "default": []
             },
-            {
-              "name": "id",
-              "type": [
-                "null",
-                "string"
-              ],
-              "default": null
-            },
-            {
-              "type": "bio.ferlab.fhir.CodeableConcept",
-              "name": "summary",
-              "default": {}
-            },
-            {
-              "name": "assessment",
-              "type": {
-                "type": "array",
-                "items": "bio.ferlab.fhir.Reference",
-                "default": []
-              },
-              "default": []
-            },
-            {
-              "type": "bio.ferlab.fhir.CodeableConcept",
-              "name": "type",
-              "default": {}
-            }
-          ],
-          "default": {}
-        },
-        "default": []
+            "default": []
+          },
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "type": "bio.ferlab.fhir.Quantity",
+            "name": "origin",
+            "default": {}
+          },
+          {
+            "name": "period",
+            "type": [
+              "null",
+              {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 18,
+                "scale": 0
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "factor",
+            "type": [
+              "null",
+              {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 18,
+                "scale": 0
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "lowerLimit",
+            "type": [
+              "null",
+              {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 18,
+                "scale": 0
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "upperLimit",
+            "type": [
+              "null",
+              {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 18,
+                "scale": 0
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "dimensions",
+            "type": [
+              "null",
+              "int"
+            ],
+            "default": null
+          },
+          {
+            "name": "data",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ],
+        "default": {}
       },
-      "default": []
+      "default": {}
     },
     {
-      "name": "evidence",
+      "name": "valueTime",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "valueDateTime",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-micros"
+        }
+      ],
+      "default": null
+    },
+    {
+      "type": "bio.ferlab.fhir.Period",
+      "name": "valuePeriod",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "dataAbsentReason",
+      "default": {}
+    },
+    {
+      "name": "interpretation",
       "type": {
         "type": "array",
-        "items": {
-          "type": "record",
-          "name": "Condition_Evidence",
-          "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
-          "namespace": "bio.ferlab.fhir",
-          "fields": [
-            {
-              "name": "extension",
-              "type": {
-                "type": "array",
-                "items": "bio.ferlab.fhir.Extension",
-                "default": []
-              },
-              "default": []
-            },
-            {
-              "name": "id",
-              "type": [
-                "null",
-                "string"
-              ],
-              "default": null
-            },
-            {
-              "name": "code",
-              "type": {
-                "type": "array",
-                "items": "bio.ferlab.fhir.CodeableConcept",
-                "default": []
-              },
-              "default": []
-            },
-            {
-              "name": "detail",
-              "type": {
-                "type": "array",
-                "items": "bio.ferlab.fhir.Reference",
-                "default": []
-              },
-              "default": []
-            }
-          ],
-          "default": {}
-        },
+        "items": "bio.ferlab.fhir.CodeableConcept",
         "default": []
       },
       "default": []
@@ -1426,6 +1669,250 @@
                 "string"
               ],
               "default": null
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "bodySite",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "method",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Reference",
+      "name": "specimen",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Reference",
+      "name": "device",
+      "default": {}
+    },
+    {
+      "name": "referenceRange",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Observation_ReferenceRange",
+          "doc": "Measurements and simple assertions made about a patient, device or other subject.",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "extension",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Extension",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "id",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.Quantity",
+              "name": "low",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Quantity",
+              "name": "high",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "type",
+              "default": {}
+            },
+            {
+              "name": "appliesTo",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.CodeableConcept",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "type": "bio.ferlab.fhir.Range",
+              "name": "age",
+              "default": {}
+            },
+            {
+              "name": "text",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "hasMember",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "derivedFrom",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "component",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Observation_Component",
+          "doc": "Measurements and simple assertions made about a patient, device or other subject.",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "extension",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Extension",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "id",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "code",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Quantity",
+              "name": "valueQuantity",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "valueCodeableConcept",
+              "default": {}
+            },
+            {
+              "name": "valueString",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueBoolean",
+              "type": [
+                "null",
+                "boolean"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueInteger",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.Range",
+              "name": "valueRange",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Ratio",
+              "name": "valueRatio",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.SampledData",
+              "name": "valueSampledData",
+              "default": {}
+            },
+            {
+              "name": "valueTime",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueDateTime",
+              "type": [
+                "null",
+                {
+                  "type": "long",
+                  "logicalType": "timestamp-micros"
+                }
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.Period",
+              "name": "valuePeriod",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "dataAbsentReason",
+              "default": {}
+            },
+            {
+              "name": "interpretation",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.CodeableConcept",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "referenceRange",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Observation_ReferenceRange",
+                "default": []
+              },
+              "default": []
             }
           ],
           "default": {}

--- a/src/resources/schemas/advanced/ncpi-phenotype.avsc
+++ b/src/resources/schemas/advanced/ncpi-phenotype.avsc
@@ -1,1 +1,1439 @@
-{"type":"record","name":"Condition","doc":"A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":{"type":"record","name":"Extension","doc":"An Extension","namespace":"bio.ferlab.fhir","fields":[{"name":"url","type":["null","string"],"default":null},{"name":"extension","type":{"type":"array","items":{"type":"record","name":"Condition.extension","doc":"An Extension","namespace":"bio.ferlab.fhir","fields":[{"name":"url","type":["null","string"],"default":null},{"name":"valueDate","type":["null",{"type":"int","logicalType":"date"}],"default":null},{"name":"valueDateTime","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"name":"valueInstant","type":["null",{"type":"long","logicalType":"timestamp-millis"}],"default":null},{"name":"valueDecimal","type":["null",{"type":"bytes","logicalType":"decimal","precision":18,"scale":0}],"default":null},{"name":"valueCoding","type":{"type":"record","name":"Coding","doc":"A reference to a code defined by a terminology system.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"system","type":["null","string"],"default":null},{"name":"version","type":["null","string"],"default":null},{"name":"code","type":["null","string"],"default":null},{"name":"display","type":["null","string"],"default":null},{"name":"userSelected","type":["null","boolean"],"default":null}],"default":{}},"default":{}},{"name":"valueCodeableConcept","type":{"type":"record","name":"CodeableConcept","doc":"A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"coding","type":{"type":"array","items":"bio.ferlab.fhir.Coding","default":[]},"default":[]},{"name":"text","type":["null","string"],"default":null}],"default":{}},"default":{}},{"name":"valueBase64Binary","type":["null","string"],"default":null},{"name":"valueBoolean","type":["null","boolean"],"default":null},{"name":"valueCanonical","type":["null","string"],"default":null},{"name":"valueCode","type":["null","string"],"default":null},{"name":"valueTime","type":["null","string"],"default":null},{"name":"valueId","type":["null","string"],"default":null},{"name":"valueInteger","type":["null","int"],"default":null},{"name":"valueMarkdown","type":["null","string"],"default":null},{"name":"valueOid","type":["null","string"],"default":null},{"name":"valuePositiveInt","type":["null","int"],"default":null},{"name":"valueString","type":["null","string"],"default":null},{"name":"valueUnsignedInt","type":["null","int"],"default":null},{"name":"valueUri","type":["null","string"],"default":null},{"name":"valueUrl","type":["null","string"],"default":null},{"name":"valueUuid","type":["null","string"],"default":null}],"default":{}},"default":[]},"default":[]},{"name":"valueDate","type":["null",{"type":"int","logicalType":"date"}],"default":null},{"name":"valueDateTime","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"name":"valueInstant","type":["null",{"type":"long","logicalType":"timestamp-millis"}],"default":null},{"name":"valueDecimal","type":["null",{"type":"bytes","logicalType":"decimal","precision":18,"scale":0}],"default":null},{"type":"bio.ferlab.fhir.Coding","name":"valueCoding","default":{}},{"type":"bio.ferlab.fhir.CodeableConcept","name":"valueCodeableConcept","default":{}},{"name":"valueBase64Binary","type":["null","string"],"default":null},{"name":"valueBoolean","type":["null","boolean"],"default":null},{"name":"valueCanonical","type":["null","string"],"default":null},{"name":"valueCode","type":["null","string"],"default":null},{"name":"valueTime","type":["null","string"],"default":null},{"name":"valueId","type":["null","string"],"default":null},{"name":"valueInteger","type":["null","int"],"default":null},{"name":"valueMarkdown","type":["null","string"],"default":null},{"name":"valueOid","type":["null","string"],"default":null},{"name":"valuePositiveInt","type":["null","int"],"default":null},{"name":"valueString","type":["null","string"],"default":null},{"name":"valueUnsignedInt","type":["null","int"],"default":null},{"name":"valueUri","type":["null","string"],"default":null},{"name":"valueUrl","type":["null","string"],"default":null},{"name":"valueUuid","type":["null","string"],"default":null}],"default":{}},"default":[]},"default":[]},{"name":"resourceType","type":"string"},{"name":"id","type":["null","string"],"default":null},{"name":"meta","type":{"type":"record","name":"Meta","doc":"The metadata about a resource. This is content in the resource that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"versionId","type":["null","string"],"default":null},{"name":"lastUpdated","type":["null",{"type":"long","logicalType":"timestamp-millis"}],"default":null},{"name":"source","type":["null","string"],"default":null},{"name":"profile","type":{"type":"array","items":{"name":"profile","type":"string"},"default":[]},"default":[]},{"name":"security","type":{"type":"array","items":"bio.ferlab.fhir.Coding","default":[]},"default":[]},{"name":"tag","type":{"type":"array","items":"bio.ferlab.fhir.Coding","default":[]},"default":[]}],"default":{}},"default":{}},{"name":"implicitRules","type":["null","string"],"default":null},{"name":"language","type":["null","string"],"default":null},{"name":"text","type":{"type":"record","name":"Narrative","doc":"A human-readable summary of the resource conveying the essential clinical and business information for the resource.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"status","type":["null","string"],"default":null},{"name":"div","type":["null","string"],"default":null}],"default":{}},"default":{}},{"name":"contained","type":{"type":"array","items":{"name":"resourcelist","type":"string"},"default":[]},"default":[]},{"name":"identifier","type":{"type":"array","items":{"type":"record","name":"Identifier","doc":"An identifier - identifies some entity uniquely and unambiguously. Typically this is used for business identifiers.","namespace":"bio.ferlab.fhir","fields":[{"name":"use","type":["null","string"],"default":null},{"name":"value","type":["null","string"],"default":null},{"name":"system","type":["null","string"],"default":null},{"type":"bio.ferlab.fhir.CodeableConcept","name":"type","default":{}},{"name":"period","type":{"type":"record","name":"Period","doc":"A time period defined by a start and end date and optionally time.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"start","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"name":"end","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null}],"default":{}},"default":{}},{"name":"assigner","type":{"type":"record","name":"Reference","doc":"A Reference","namespace":"bio.ferlab.fhir","fields":[{"name":"reference","type":["null","string"],"default":null},{"name":"type","type":["null","string"],"default":null},{"name":"identifier","type":["null","string"],"default":null},{"name":"display","type":["null","string"],"default":null}],"default":{}},"default":{}}],"default":{}},"default":[]},"default":[]},{"type":"bio.ferlab.fhir.CodeableConcept","name":"clinicalStatus","default":{}},{"type":"bio.ferlab.fhir.CodeableConcept","name":"verificationStatus","default":{}},{"name":"category","type":{"type":"array","items":"bio.ferlab.fhir.CodeableConcept","default":[]},"default":[]},{"type":"bio.ferlab.fhir.CodeableConcept","name":"severity","default":{}},{"type":"bio.ferlab.fhir.CodeableConcept","name":"code","default":{}},{"name":"bodySite","type":{"type":"array","items":"bio.ferlab.fhir.CodeableConcept","default":[]},"default":[]},{"type":"bio.ferlab.fhir.Reference","name":"subject","default":{}},{"type":"bio.ferlab.fhir.Reference","name":"encounter","default":{}},{"name":"onsetDateTime","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"name":"onsetAge","type":{"type":"record","name":"Age","doc":"A duration of time during which an organism (or a process) has existed.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"value","type":["null",{"type":"bytes","logicalType":"decimal","precision":18,"scale":0}],"default":null},{"name":"comparator","type":["null","string"],"default":null},{"name":"unit","type":["null","string"],"default":null},{"name":"system","type":["null","string"],"default":null},{"name":"code","type":["null","string"],"default":null}],"default":{}},"default":{}},{"type":"bio.ferlab.fhir.Period","name":"onsetPeriod","default":{}},{"name":"onsetRange","type":{"type":"record","name":"Range","doc":"A set of ordered Quantities defined by a low and high limit.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"low","type":{"type":"record","name":"Quantity","doc":"A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"value","type":["null",{"type":"bytes","logicalType":"decimal","precision":18,"scale":0}],"default":null},{"name":"comparator","type":["null","string"],"default":null},{"name":"unit","type":["null","string"],"default":null},{"name":"system","type":["null","string"],"default":null},{"name":"code","type":["null","string"],"default":null}],"default":{}},"default":{}},{"type":"bio.ferlab.fhir.Quantity","name":"high","default":{}}],"default":{}},"default":{}},{"name":"onsetString","type":["null","string"],"default":null},{"name":"abatementDateTime","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"type":"bio.ferlab.fhir.Age","name":"abatementAge","default":{}},{"type":"bio.ferlab.fhir.Period","name":"abatementPeriod","default":{}},{"type":"bio.ferlab.fhir.Range","name":"abatementRange","default":{}},{"name":"abatementString","type":["null","string"],"default":null},{"name":"recordedDate","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"type":"bio.ferlab.fhir.Reference","name":"recorder","default":{}},{"type":"bio.ferlab.fhir.Reference","name":"asserter","default":{}},{"name":"stage","type":{"type":"array","items":{"type":"record","name":"Condition_Stage","doc":"A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"type":"bio.ferlab.fhir.CodeableConcept","name":"summary","default":{}},{"name":"assessment","type":{"type":"array","items":"bio.ferlab.fhir.Reference","default":[]},"default":[]},{"type":"bio.ferlab.fhir.CodeableConcept","name":"type","default":{}}],"default":{}},"default":[]},"default":[]},{"name":"evidence","type":{"type":"array","items":{"type":"record","name":"Condition_Evidence","doc":"A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"name":"code","type":{"type":"array","items":"bio.ferlab.fhir.CodeableConcept","default":[]},"default":[]},{"name":"detail","type":{"type":"array","items":"bio.ferlab.fhir.Reference","default":[]},"default":[]}],"default":{}},"default":[]},"default":[]},{"name":"note","type":{"type":"array","items":{"type":"record","name":"Annotation","doc":"A  text note which also  contains information about who made the statement and when.","namespace":"bio.ferlab.fhir","fields":[{"name":"extension","type":{"type":"array","items":"bio.ferlab.fhir.Extension","default":[]},"default":[]},{"name":"id","type":["null","string"],"default":null},{"type":"bio.ferlab.fhir.Reference","name":"authorReference","default":{}},{"name":"authorString","type":["null","string"],"default":null},{"name":"time","type":["null",{"type":"long","logicalType":"timestamp-micros"}],"default":null},{"name":"text","type":["null","string"],"default":null}],"default":{}},"default":[]},"default":[]}],"default":null}
+{
+  "type": "record",
+  "name": "Condition",
+  "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+  "namespace": "bio.ferlab.fhir",
+  "fields": [
+    {
+      "name": "extension",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Extension",
+          "doc": "An Extension",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "url",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "extension",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "Condition.extension",
+                  "doc": "An Extension",
+                  "namespace": "bio.ferlab.fhir",
+                  "fields": [
+                    {
+                      "name": "url",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueDate",
+                      "type": [
+                        "null",
+                        {
+                          "type": "int",
+                          "logicalType": "date"
+                        }
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueDateTime",
+                      "type": [
+                        "null",
+                        {
+                          "type": "long",
+                          "logicalType": "timestamp-micros"
+                        }
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueInstant",
+                      "type": [
+                        "null",
+                        {
+                          "type": "long",
+                          "logicalType": "timestamp-millis"
+                        }
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueDecimal",
+                      "type": [
+                        "null",
+                        {
+                          "type": "bytes",
+                          "logicalType": "decimal",
+                          "precision": 18,
+                          "scale": 0
+                        }
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueCoding",
+                      "type": {
+                        "type": "record",
+                        "name": "Coding",
+                        "doc": "A reference to a code defined by a terminology system.",
+                        "namespace": "bio.ferlab.fhir",
+                        "fields": [
+                          {
+                            "name": "extension",
+                            "type": {
+                              "type": "array",
+                              "items": "bio.ferlab.fhir.Extension",
+                              "default": []
+                            },
+                            "default": []
+                          },
+                          {
+                            "name": "id",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "system",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "version",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "code",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "display",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "userSelected",
+                            "type": [
+                              "null",
+                              "boolean"
+                            ],
+                            "default": null
+                          }
+                        ],
+                        "default": {}
+                      },
+                      "default": {}
+                    },
+                    {
+                      "name": "valueCodeableConcept",
+                      "type": {
+                        "type": "record",
+                        "name": "CodeableConcept",
+                        "doc": "A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.",
+                        "namespace": "bio.ferlab.fhir",
+                        "fields": [
+                          {
+                            "name": "extension",
+                            "type": {
+                              "type": "array",
+                              "items": "bio.ferlab.fhir.Extension",
+                              "default": []
+                            },
+                            "default": []
+                          },
+                          {
+                            "name": "id",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "coding",
+                            "type": {
+                              "type": "array",
+                              "items": "bio.ferlab.fhir.Coding",
+                              "default": []
+                            },
+                            "default": []
+                          },
+                          {
+                            "name": "text",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          }
+                        ],
+                        "default": {}
+                      },
+                      "default": {}
+                    },
+                    {
+                      "name": "valueDuration",
+                      "type": {
+                        "type": "record",
+                        "name": "Duration",
+                        "doc": "A length of time.",
+                        "namespace": "bio.ferlab.fhir",
+                        "fields": [
+                          {
+                            "name": "extension",
+                            "type": {
+                              "type": "array",
+                              "items": "bio.ferlab.fhir.Extension",
+                              "default": []
+                            },
+                            "default": []
+                          },
+                          {
+                            "name": "id",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "value",
+                            "type": [
+                              "null",
+                              {
+                                "type": "bytes",
+                                "logicalType": "decimal",
+                                "precision": 18,
+                                "scale": 0
+                              }
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "comparator",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "unit",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "system",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "code",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          }
+                        ],
+                        "default": {}
+                      },
+                      "default": {}
+                    },
+                    {
+                      "name": "valueBase64Binary",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueBoolean",
+                      "type": [
+                        "null",
+                        "boolean"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueCanonical",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueCode",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueTime",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueId",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueInteger",
+                      "type": [
+                        "null",
+                        "int"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueMarkdown",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueOid",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valuePositiveInt",
+                      "type": [
+                        "null",
+                        "int"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueString",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueUnsignedInt",
+                      "type": [
+                        "null",
+                        "int"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueUri",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueUrl",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "name": "valueUuid",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    },
+                    {
+                      "type": {
+                        "type": "record",
+                        "name": "Reference",
+                        "doc": "A Reference",
+                        "namespace": "bio.ferlab.fhir",
+                        "fields": [
+                          {
+                            "name": "reference",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "type",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "identifier",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          },
+                          {
+                            "name": "display",
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "default": null
+                          }
+                        ],
+                        "logicalType": "reference",
+                        "idFieldName": "identifier",
+                        "default": {}
+                      },
+                      "name": "valueReference",
+                      "default": {}
+                    }
+                  ],
+                  "default": {}
+                },
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "valueDate",
+              "type": [
+                "null",
+                {
+                  "type": "int",
+                  "logicalType": "date"
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "valueDateTime",
+              "type": [
+                "null",
+                {
+                  "type": "long",
+                  "logicalType": "timestamp-micros"
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "valueInstant",
+              "type": [
+                "null",
+                {
+                  "type": "long",
+                  "logicalType": "timestamp-millis"
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "valueDecimal",
+              "type": [
+                "null",
+                {
+                  "type": "bytes",
+                  "logicalType": "decimal",
+                  "precision": 18,
+                  "scale": 0
+                }
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.Coding",
+              "name": "valueCoding",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Reference",
+              "name": "valueReference",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "valueCodeableConcept",
+              "default": {}
+            },
+            {
+              "name": "valueDuration",
+              "type": "bio.ferlab.fhir.Duration",
+              "default": {}
+            },
+            {
+              "name": "valueBase64Binary",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueBoolean",
+              "type": [
+                "null",
+                "boolean"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueCanonical",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueCode",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueTime",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueId",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueInteger",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueMarkdown",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueOid",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valuePositiveInt",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueString",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueUnsignedInt",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueUri",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueUrl",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "valueUuid",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "resourceType",
+      "type": "string"
+    },
+    {
+      "name": "id",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "meta",
+      "type": {
+        "type": "record",
+        "name": "Meta",
+        "doc": "The metadata about a resource. This is content in the resource that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "versionId",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "lastUpdated",
+            "type": [
+              "null",
+              {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "source",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "profile",
+            "type": {
+              "type": "array",
+              "items": {
+                "name": "profile",
+                "type": "string"
+              },
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "security",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Coding",
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "tag",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Coding",
+              "default": []
+            },
+            "default": []
+          }
+        ],
+        "default": {}
+      },
+      "default": {}
+    },
+    {
+      "name": "implicitRules",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "language",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "text",
+      "type": {
+        "type": "record",
+        "name": "Narrative",
+        "doc": "A human-readable summary of the resource conveying the essential clinical and business information for the resource.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "status",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "div",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ],
+        "default": {}
+      },
+      "default": {}
+    },
+    {
+      "name": "contained",
+      "type": {
+        "type": "array",
+        "items": {
+          "name": "resourcelist",
+          "type": "string"
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "identifier",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Identifier",
+          "doc": "An identifier - identifies some entity uniquely and unambiguously. Typically this is used for business identifiers.",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "use",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "value",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "system",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "type",
+              "default": {}
+            },
+            {
+              "name": "period",
+              "type": {
+                "type": "record",
+                "name": "Period",
+                "doc": "A time period defined by a start and end date and optionally time.",
+                "namespace": "bio.ferlab.fhir",
+                "fields": [
+                  {
+                    "name": "extension",
+                    "type": {
+                      "type": "array",
+                      "items": "bio.ferlab.fhir.Extension",
+                      "default": []
+                    },
+                    "default": []
+                  },
+                  {
+                    "name": "id",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "start",
+                    "type": [
+                      "null",
+                      {
+                        "type": "long",
+                        "logicalType": "timestamp-micros"
+                      }
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "end",
+                    "type": [
+                      "null",
+                      {
+                        "type": "long",
+                        "logicalType": "timestamp-micros"
+                      }
+                    ],
+                    "default": null
+                  }
+                ],
+                "default": {}
+              },
+              "default": {}
+            },
+            {
+              "name": "assigner",
+              "type": "bio.ferlab.fhir.Reference",
+              "default": {}
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "clinicalStatus",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "verificationStatus",
+      "default": {}
+    },
+    {
+      "name": "category",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.CodeableConcept",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "severity",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.CodeableConcept",
+      "name": "code",
+      "default": {}
+    },
+    {
+      "name": "bodySite",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.CodeableConcept",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "type": "bio.ferlab.fhir.Reference",
+      "name": "subject",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Reference",
+      "name": "encounter",
+      "default": {}
+    },
+    {
+      "name": "onsetDateTime",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-micros"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "onsetAge",
+      "type": {
+        "type": "record",
+        "name": "Age",
+        "doc": "A duration of time during which an organism (or a process) has existed.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "value",
+            "type": [
+              "null",
+              {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 18,
+                "scale": 0
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "comparator",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "unit",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "system",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "code",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ],
+        "default": {}
+      },
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Period",
+      "name": "onsetPeriod",
+      "default": {}
+    },
+    {
+      "name": "onsetRange",
+      "type": {
+        "type": "record",
+        "name": "Range",
+        "doc": "A set of ordered Quantities defined by a low and high limit.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          },
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "low",
+            "type": {
+              "type": "record",
+              "name": "Quantity",
+              "doc": "A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.",
+              "namespace": "bio.ferlab.fhir",
+              "fields": [
+                {
+                  "name": "extension",
+                  "type": {
+                    "type": "array",
+                    "items": "bio.ferlab.fhir.Extension",
+                    "default": []
+                  },
+                  "default": []
+                },
+                {
+                  "name": "id",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "value",
+                  "type": [
+                    "null",
+                    {
+                      "type": "bytes",
+                      "logicalType": "decimal",
+                      "precision": 18,
+                      "scale": 0
+                    }
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "comparator",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "unit",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "system",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "code",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ],
+              "default": {}
+            },
+            "default": {}
+          },
+          {
+            "type": "bio.ferlab.fhir.Quantity",
+            "name": "high",
+            "default": {}
+          }
+        ],
+        "default": {}
+      },
+      "default": {}
+    },
+    {
+      "name": "onsetString",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "abatementDateTime",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-micros"
+        }
+      ],
+      "default": null
+    },
+    {
+      "type": "bio.ferlab.fhir.Age",
+      "name": "abatementAge",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Period",
+      "name": "abatementPeriod",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Range",
+      "name": "abatementRange",
+      "default": {}
+    },
+    {
+      "name": "abatementString",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "recordedDate",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-micros"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "_recordedDate",
+      "type": {
+        "type": "record",
+        "name": "Element",
+        "doc": "Base definition for all elements in a resource.",
+        "namespace": "bio.ferlab.fhir",
+        "fields": [
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
+          }
+        ],
+        "default": {}
+      },
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Reference",
+      "name": "recorder",
+      "default": {}
+    },
+    {
+      "type": "bio.ferlab.fhir.Reference",
+      "name": "asserter",
+      "default": {}
+    },
+    {
+      "name": "stage",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Condition_Stage",
+          "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "extension",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Extension",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "id",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "summary",
+              "default": {}
+            },
+            {
+              "name": "assessment",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Reference",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "type",
+              "default": {}
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "evidence",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Condition_Evidence",
+          "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "extension",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Extension",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "id",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "code",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.CodeableConcept",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "detail",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Reference",
+                "default": []
+              },
+              "default": []
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "note",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Annotation",
+          "doc": "A  text note which also  contains information about who made the statement and when.",
+          "namespace": "bio.ferlab.fhir",
+          "fields": [
+            {
+              "name": "extension",
+              "type": {
+                "type": "array",
+                "items": "bio.ferlab.fhir.Extension",
+                "default": []
+              },
+              "default": []
+            },
+            {
+              "name": "id",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.Reference",
+              "name": "authorReference",
+              "default": {}
+            },
+            {
+              "name": "authorString",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "time",
+              "type": [
+                "null",
+                {
+                  "type": "long",
+                  "logicalType": "timestamp-micros"
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "text",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            }
+          ],
+          "default": {}
+        },
+        "default": []
+      },
+      "default": []
+    }
+  ],
+  "default": null
+}

--- a/src/resources/schemas/advanced/ncpi-specimen.avsc
+++ b/src/resources/schemas/advanced/ncpi-specimen.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
-  "name": "Condition",
-  "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+  "name": "Specimen",
+  "doc": "A sample to be used for analysis.",
   "namespace": "bio.ferlab.fhir",
   "fields": [
     {
@@ -922,42 +922,22 @@
       "default": []
     },
     {
-      "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "clinicalStatus",
+      "type": "bio.ferlab.fhir.Identifier",
+      "name": "accessionIdentifier",
       "default": {}
     },
     {
-      "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "verificationStatus",
-      "default": {}
-    },
-    {
-      "name": "category",
-      "type": {
-        "type": "array",
-        "items": "bio.ferlab.fhir.CodeableConcept",
-        "default": []
-      },
-      "default": []
+      "name": "status",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "severity",
+      "name": "type",
       "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.CodeableConcept",
-      "name": "code",
-      "default": {}
-    },
-    {
-      "name": "bodySite",
-      "type": {
-        "type": "array",
-        "items": "bio.ferlab.fhir.CodeableConcept",
-        "default": []
-      },
-      "default": []
     },
     {
       "type": "bio.ferlab.fhir.Reference",
@@ -965,12 +945,7 @@
       "default": {}
     },
     {
-      "type": "bio.ferlab.fhir.Reference",
-      "name": "encounter",
-      "default": {}
-    },
-    {
-      "name": "onsetDateTime",
+      "name": "receivedTime",
       "type": [
         "null",
         {
@@ -981,22 +956,13 @@
       "default": null
     },
     {
-      "name": "onsetAge",
+      "name": "_receivedTime",
       "type": {
         "type": "record",
-        "name": "Age",
-        "doc": "A duration of time during which an organism (or a process) has existed.",
+        "name": "Element",
+        "doc": "Base definition for all elements in a resource.",
         "namespace": "bio.ferlab.fhir",
         "fields": [
-          {
-            "name": "extension",
-            "type": {
-              "type": "array",
-              "items": "bio.ferlab.fhir.Extension",
-              "default": []
-            },
-            "default": []
-          },
           {
             "name": "id",
             "type": [
@@ -1006,49 +972,13 @@
             "default": null
           },
           {
-            "name": "value",
-            "type": [
-              "null",
-              {
-                "type": "bytes",
-                "logicalType": "decimal",
-                "precision": 18,
-                "scale": 0
-              }
-            ],
-            "default": null
-          },
-          {
-            "name": "comparator",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "unit",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "system",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "code",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
+            "name": "extension",
+            "type": {
+              "type": "array",
+              "items": "bio.ferlab.fhir.Extension",
+              "default": []
+            },
+            "default": []
           }
         ],
         "default": {}
@@ -1056,16 +986,29 @@
       "default": {}
     },
     {
-      "type": "bio.ferlab.fhir.Period",
-      "name": "onsetPeriod",
-      "default": {}
+      "name": "parent",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
     },
     {
-      "name": "onsetRange",
+      "name": "request",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.Reference",
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "collection",
       "type": {
         "type": "record",
-        "name": "Range",
-        "doc": "A set of ordered Quantities defined by a low and high limit.",
+        "name": "Specimen_Collection",
+        "doc": "A sample to be used for analysis.",
         "namespace": "bio.ferlab.fhir",
         "fields": [
           {
@@ -1086,7 +1029,33 @@
             "default": null
           },
           {
-            "name": "low",
+            "type": "bio.ferlab.fhir.Reference",
+            "name": "collector",
+            "default": {}
+          },
+          {
+            "name": "collectedDateTime",
+            "type": [
+              "null",
+              {
+                "type": "long",
+                "logicalType": "timestamp-micros"
+              }
+            ],
+            "default": null
+          },
+          {
+            "type": "bio.ferlab.fhir.Period",
+            "name": "collectedPeriod",
+            "default": {}
+          },
+          {
+            "type": "bio.ferlab.fhir.Duration",
+            "name": "duration",
+            "default": {}
+          },
+          {
+            "name": "quantity",
             "type": {
               "type": "record",
               "name": "Quantity",
@@ -1161,8 +1130,23 @@
             "default": {}
           },
           {
-            "type": "bio.ferlab.fhir.Quantity",
-            "name": "high",
+            "type": "bio.ferlab.fhir.CodeableConcept",
+            "name": "method",
+            "default": {}
+          },
+          {
+            "type": "bio.ferlab.fhir.CodeableConcept",
+            "name": "bodySite",
+            "default": {}
+          },
+          {
+            "type": "bio.ferlab.fhir.CodeableConcept",
+            "name": "fastingStatusCodeableConcept",
+            "default": {}
+          },
+          {
+            "type": "bio.ferlab.fhir.Duration",
+            "name": "fastingStatusDuration",
             "default": {}
           }
         ],
@@ -1171,106 +1155,13 @@
       "default": {}
     },
     {
-      "name": "onsetString",
-      "type": [
-        "null",
-        "string"
-      ],
-      "default": null
-    },
-    {
-      "name": "abatementDateTime",
-      "type": [
-        "null",
-        {
-          "type": "long",
-          "logicalType": "timestamp-micros"
-        }
-      ],
-      "default": null
-    },
-    {
-      "type": "bio.ferlab.fhir.Age",
-      "name": "abatementAge",
-      "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.Period",
-      "name": "abatementPeriod",
-      "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.Range",
-      "name": "abatementRange",
-      "default": {}
-    },
-    {
-      "name": "abatementString",
-      "type": [
-        "null",
-        "string"
-      ],
-      "default": null
-    },
-    {
-      "name": "recordedDate",
-      "type": [
-        "null",
-        {
-          "type": "long",
-          "logicalType": "timestamp-micros"
-        }
-      ],
-      "default": null
-    },
-    {
-      "name": "_recordedDate",
-      "type": {
-        "type": "record",
-        "name": "Element",
-        "doc": "Base definition for all elements in a resource.",
-        "namespace": "bio.ferlab.fhir",
-        "fields": [
-          {
-            "name": "id",
-            "type": [
-              "null",
-              "string"
-            ],
-            "default": null
-          },
-          {
-            "name": "extension",
-            "type": {
-              "type": "array",
-              "items": "bio.ferlab.fhir.Extension",
-              "default": []
-            },
-            "default": []
-          }
-        ],
-        "default": {}
-      },
-      "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.Reference",
-      "name": "recorder",
-      "default": {}
-    },
-    {
-      "type": "bio.ferlab.fhir.Reference",
-      "name": "asserter",
-      "default": {}
-    },
-    {
-      "name": "stage",
+      "name": "processing",
       "type": {
         "type": "array",
         "items": {
           "type": "record",
-          "name": "Condition_Stage",
-          "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+          "name": "Specimen_Processing",
+          "doc": "A sample to be used for analysis.",
           "namespace": "bio.ferlab.fhir",
           "fields": [
             {
@@ -1291,12 +1182,20 @@
               "default": null
             },
             {
+              "name": "description",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
               "type": "bio.ferlab.fhir.CodeableConcept",
-              "name": "summary",
+              "name": "procedure",
               "default": {}
             },
             {
-              "name": "assessment",
+              "name": "additive",
               "type": {
                 "type": "array",
                 "items": "bio.ferlab.fhir.Reference",
@@ -1305,8 +1204,19 @@
               "default": []
             },
             {
-              "type": "bio.ferlab.fhir.CodeableConcept",
-              "name": "type",
+              "name": "timeDateTime",
+              "type": [
+                "null",
+                {
+                  "type": "long",
+                  "logicalType": "timestamp-micros"
+                }
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.Period",
+              "name": "timePeriod",
               "default": {}
             }
           ],
@@ -1317,13 +1227,13 @@
       "default": []
     },
     {
-      "name": "evidence",
+      "name": "container",
       "type": {
         "type": "array",
         "items": {
           "type": "record",
-          "name": "Condition_Evidence",
-          "doc": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
+          "name": "Specimen_Container",
+          "doc": "A sample to be used for analysis.",
           "namespace": "bio.ferlab.fhir",
           "fields": [
             {
@@ -1344,26 +1254,59 @@
               "default": null
             },
             {
-              "name": "code",
+              "name": "identifier",
               "type": {
                 "type": "array",
-                "items": "bio.ferlab.fhir.CodeableConcept",
+                "items": "bio.ferlab.fhir.Identifier",
                 "default": []
               },
               "default": []
             },
             {
-              "name": "detail",
-              "type": {
-                "type": "array",
-                "items": "bio.ferlab.fhir.Reference",
-                "default": []
-              },
-              "default": []
+              "name": "description",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "type",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Quantity",
+              "name": "capacity",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Quantity",
+              "name": "specimenQuantity",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.CodeableConcept",
+              "name": "additiveCodeableConcept",
+              "default": {}
+            },
+            {
+              "type": "bio.ferlab.fhir.Reference",
+              "name": "additiveReference",
+              "default": {}
             }
           ],
           "default": {}
         },
+        "default": []
+      },
+      "default": []
+    },
+    {
+      "name": "condition",
+      "type": {
+        "type": "array",
+        "items": "bio.ferlab.fhir.CodeableConcept",
         "default": []
       },
       "default": []


### PR DESCRIPTION
- Schemas have been manually written for now, we are looking at creating an example of a profile which has pre-defined Element definition in order to avoid defining ALL elements in schema.