### PR TITLE
fix: to exclude 2 value fields that are not real value[x] fields

### DIFF
--- a/src/main/java/bio/ferlab/fhir/converter/FhirAvroConverter.java
+++ b/src/main/java/bio/ferlab/fhir/converter/FhirAvroConverter.java
@@ -11,10 +11,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.text.WordUtils;
-import org.hl7.fhir.r4.model.Base;
-import org.hl7.fhir.r4.model.BaseResource;
-import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.Property;
+import org.hl7.fhir.r4.model.*;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -141,9 +138,13 @@ public class FhirAvroConverter {
         return ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8));
     }
 
+    private static Boolean isNotRealValueXField(Base base, String fieldName) {
+        return base instanceof Device.DevicePropertyComponent && (fieldName.equals("valueQuantity") || fieldName.equals("valueCode"));
+    }
+
     private static Optional<Property> getProperty(Base base, Schema.Field field) {
         // Support value[x] notation.
-        if (Pattern.compile("value[a-zA-Z].*").matcher(field.name()).matches()) {
+        if (Pattern.compile("value[a-zA-Z].*").matcher(field.name()).matches() && !isNotRealValueXField(base, field.name())) {
             Property property = base.getNamedProperty(Constant.VALUE);
             if (property != null && property.hasValues()) {
                 // Try to find the valid corresponding value[x] by comparing the FhirType and the field name.

--- a/src/main/java/bio/ferlab/fhir/converter/FhirAvroConverter.java
+++ b/src/main/java/bio/ferlab/fhir/converter/FhirAvroConverter.java
@@ -138,13 +138,13 @@ public class FhirAvroConverter {
         return ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static Boolean isNotRealValueXField(Base base, String fieldName) {
-        return base instanceof Device.DevicePropertyComponent && (fieldName.equals("valueQuantity") || fieldName.equals("valueCode"));
+    private static Boolean isRealValueXField(Base base, String fieldName) {
+        return !(base instanceof Device.DevicePropertyComponent) || (!fieldName.equals("valueQuantity") && !fieldName.equals("valueCode"));
     }
 
     private static Optional<Property> getProperty(Base base, Schema.Field field) {
         // Support value[x] notation.
-        if (Pattern.compile("value[a-zA-Z].*").matcher(field.name()).matches() && !isNotRealValueXField(base, field.name())) {
+        if (Pattern.compile("value[a-zA-Z].*").matcher(field.name()).matches() && isRealValueXField(base, field.name())) {
             Property property = base.getNamedProperty(Constant.VALUE);
             if (property != null && property.hasValues()) {
                 // Try to find the valid corresponding value[x] by comparing the FhirType and the field name.


### PR DESCRIPTION
L'idée est de ne pas traiter ces 2 champs spécifiques comme des value[x] vu qu'ils n'en sont pas. Le problème est présent uniquement en R4 (fixé sur R5)
<img width="1071" alt="Capture d’écran, le 2024-10-03 à 17 03 18" src="https://github.com/user-attachments/assets/9d08dc60-fd6b-4cac-92ab-dd8a19b3c9e4">
